### PR TITLE
feat: add Lesson 3 – structured output with prebuilt agents

### DIFF
--- a/03_structured_output_with_prebuilt_agents.ipynb
+++ b/03_structured_output_with_prebuilt_agents.ipynb
@@ -1,0 +1,361 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0a01e071",
+   "metadata": {},
+   "source": [
+    "# Prebuilt ReAct Agent - Structured Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ba61b5c",
+   "metadata": {},
+   "source": [
+    "## Define tools explicitly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89f94053",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import yfinance as yf\n",
+    "from pprint import pformat\n",
+    "from langchain_core.tools import tool\n",
+    "\n",
+    "@tool(\"lookup_stock\")\n",
+    "def lookup_stock_symbol(company_name: str) -> str:\n",
+    "    \"\"\"\n",
+    "    Converts a company name to its stock symbol using a financial API.\n",
+    "\n",
+    "    Parameters:\n",
+    "        company_name (str): The full company name (e.g., 'Tesla').\n",
+    "\n",
+    "    Returns:\n",
+    "        str: The stock symbol (e.g., 'TSLA') or an error message.\n",
+    "    \"\"\"\n",
+    "    api_url = \"https://www.alphavantage.co/query\"\n",
+    "    params = {\n",
+    "        \"function\": \"SYMBOL_SEARCH\",\n",
+    "        \"keywords\": company_name,\n",
+    "        \"apikey\": \"your_alphavantage_api_key\"\n",
+    "    }\n",
+    "    \n",
+    "    response = requests.get(api_url, params=params)\n",
+    "    data = response.json()\n",
+    "    \n",
+    "    if \"bestMatches\" in data and data[\"bestMatches\"]:\n",
+    "        return data[\"bestMatches\"][0][\"1. symbol\"]\n",
+    "    else:\n",
+    "        return f\"Symbol not found for {company_name}.\"\n",
+    "\n",
+    "\n",
+    "@tool(\"fetch_stock_data\")\n",
+    "def fetch_stock_data_raw(stock_symbol: str) -> dict:\n",
+    "    \"\"\"\n",
+    "    Fetches comprehensive stock data for a given symbol and returns it as a combined dictionary.\n",
+    "\n",
+    "    Parameters:\n",
+    "        stock_symbol (str): The stock ticker symbol (e.g., 'TSLA').\n",
+    "        period (str): The period to analyze (e.g., '1mo', '3mo', '1y').\n",
+    "\n",
+    "    Returns:\n",
+    "        dict: A dictionary combining general stock info and historical market data.\n",
+    "    \"\"\"\n",
+    "    period = \"1mo\"\n",
+    "    try:\n",
+    "        stock = yf.Ticker(stock_symbol)\n",
+    "\n",
+    "        # Retrieve general stock info and historical market data\n",
+    "        stock_info = stock.info  # Basic company and stock data\n",
+    "        stock_history = stock.history(period=period).to_dict()  # Historical OHLCV data\n",
+    "\n",
+    "        # Combine both into a single dictionary\n",
+    "        combined_data = {\n",
+    "            \"stock_symbol\": stock_symbol,\n",
+    "            \"info\": stock_info,\n",
+    "            \"history\": stock_history\n",
+    "        }\n",
+    "\n",
+    "        return pformat(combined_data)\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        return {\"error\": f\"Error fetching stock data for {stock_symbol}: {str(e)}\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27cf90aa",
+   "metadata": {},
+   "source": [
+    "## Define the basic agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71b80d2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.prebuilt import create_react_agent\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from IPython.display import Image, display\n",
+    "\n",
+    "agent = create_react_agent(\n",
+    "    model=ChatOpenAI(model=\"gpt-4o-mini\"),\n",
+    "    tools=[lookup_stock_symbol, fetch_stock_data_raw],\n",
+    "    prompt=\"You are a financial advisor. Give clear analysis of risks and opportunities.\"\n",
+    ")\n",
+    "\n",
+    "display(Image(agent.get_graph().draw_mermaid_png()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "414d1795",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = agent.invoke({\"messages\": [HumanMessage(content=\"Analyze stock symbol TSLA and provide a financial summary.\")]})\n",
+    "for message in response['messages']:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b19996fe",
+   "metadata": {},
+   "source": [
+    "## Structured Output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "096c9588",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel, Field\n",
+    "from typing import List, Optional\n",
+    "\n",
+    "class FinancialInfo(BaseModel):\n",
+    "    company_name: str = Field(\n",
+    "        description=\"The full name of the company being analyzed.\"\n",
+    "    )\n",
+    "    stock_symbol: str = Field(\n",
+    "        description=\"The stock ticker symbol for the company (e.g., 'AAPL' for Apple).\"\n",
+    "    )\n",
+    "    current_price: float = Field(\n",
+    "        description=\"The most recent stock price in USD.\"\n",
+    "    )\n",
+    "    market_cap: Optional[float] = Field(\n",
+    "        description=\"The market capitalization of the company in billions USD.\",\n",
+    "        default=None\n",
+    "    )\n",
+    "    summary: str = Field(\n",
+    "        description=\"A brief 2-3 sentence summary of the company's current financial status and recent performance.\"\n",
+    "    )\n",
+    "    risk_assessment: str = Field(\n",
+    "        description=\"Assessment of investment risk as 'Low', 'Moderate', or 'High' with brief explanation.\"\n",
+    "    )\n",
+    "\n",
+    "agent = create_react_agent(\n",
+    "    model=ChatOpenAI(model=\"gpt-4o-mini\"),\n",
+    "    tools=[lookup_stock_symbol, fetch_stock_data_raw],\n",
+    "    prompt=\"You are a financial advisor. Analyze the requested company and provide a structured assessment.\",\n",
+    "    response_format=FinancialInfo,\n",
+    "    version=\"v2\"\n",
+    ")\n",
+    "\n",
+    "display(Image(agent.get_graph().draw_mermaid_png()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f75cc349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage\n",
+    "import json\n",
+    "\n",
+    "response = agent.invoke({\"messages\": [HumanMessage(content=\"Analyze stock symbol TSLA and provide a financial summary.\")]})\n",
+    "structured_output = response['structured_response']\n",
+    "print(json.dumps(structured_output.model_dump(), indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2399c37c",
+   "metadata": {},
+   "source": [
+    "The graph will make a separate call to the LLM to generate the structured response after the agent loop is finished. Check traces in LangSmith.\n",
+    "\n",
+    "### Problems with Using a Separate \"generate_structured_response\" Node\n",
+    "\n",
+    "1. **Extra API Cost**: An additional LLM call that could be avoided.\n",
+    "\n",
+    "2. **Less Agent Control**: The agent can't decide when or if structured output should be generated - it's automatic.\n",
+    "\n",
+    "3. **Workflow Rigidity**: Output generation happens regardless of whether sufficient data was collected.\n",
+    "\n",
+    "\n",
+    "Possible workaround - use the FinancialInfo as a tool as its final step, so then it creates the structured output while context is still there."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cfef83b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"You are a financial advisor. Analyze the requested company and provide a structured assessment.\n",
+    "\n",
+    "IMPORTANT: When you have gathered all necessary data, call the FinancialInfo tool with your findings.\n",
+    "After receiving the structured data from the FinancialInfo tool, DO NOT add any additional commentary.\n",
+    "Simply return the structured data as your final response.\"\"\"\n",
+    "\n",
+    "agent = create_react_agent(\n",
+    "    model=ChatOpenAI(model=\"gpt-4o-mini\"),\n",
+    "    tools=[lookup_stock_symbol, fetch_stock_data_raw, FinancialInfo],\n",
+    "    prompt=system_prompt\n",
+    ")\n",
+    "\n",
+    "display(Image(agent.get_graph().draw_mermaid_png()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c164a61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage\n",
+    "\n",
+    "response = agent.invoke({\"messages\": [HumanMessage(content=\"Analyze stock symbol TSLA and provide a financial summary.\")]})\n",
+    "\n",
+    "for message in response['messages']:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26c12970",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Optional\n",
+    "from langgraph.graph import MessagesState\n",
+    "\n",
+    "def post_model_hook(state):\n",
+    "    \"\"\"Extract structured data from FinancialInfo tool calls\"\"\"\n",
+    "    latest_message = state[\"messages\"][-1]\n",
+    "    \n",
+    "    if hasattr(latest_message, \"tool_calls\"):\n",
+    "        for tool_call in latest_message.tool_calls:\n",
+    "            if tool_call[\"name\"] == \"FinancialInfo\":\n",
+    "                structured_data = tool_call[\"args\"]\n",
+    "                return {\"structured_response\": FinancialInfo(**structured_data)}\n",
+    "    \n",
+    "    return {}\n",
+    "\n",
+    "\n",
+    "# we need our own state so we can add a new attribute \"structured_response\" that will be recognized by \"post_model_hook\"\n",
+    "class AgentState(MessagesState):\n",
+    "    remaining_steps: int    \n",
+    "    structured_response: Optional[FinancialInfo] = None\n",
+    "\n",
+    "\n",
+    "system_message = \"\"\"You are a financial advisor. Analyze the requested company and provide a structured response using FinancialInfo tool.\"\"\"\n",
+    "\n",
+    "agent = create_react_agent(\n",
+    "    model=ChatOpenAI(model=\"gpt-4o-mini\"),\n",
+    "    tools=[lookup_stock_symbol, fetch_stock_data_raw, FinancialInfo],\n",
+    "    prompt=system_message,\n",
+    "\n",
+    "    post_model_hook=post_model_hook,\n",
+    "    version=\"v2\",\n",
+    "    state_schema=AgentState\n",
+    ")\n",
+    "\n",
+    "display(Image(agent.get_graph().draw_mermaid_png()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95b41fa9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage\n",
+    "import json\n",
+    "\n",
+    "response = agent.invoke({\"messages\": [HumanMessage(content=\"Analyze stock symbol TSLA and provide a financial summary.\")]})\n",
+    "structured_output = response.get('structured_response')\n",
+    "print(json.dumps(structured_output.model_dump(), indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "091eb0e8",
+   "metadata": {},
+   "source": [
+    "## Reference Links\n",
+    "\n",
+    "**1. LangGraph create_react_agent API Reference**\n",
+    "\n",
+    "https://langchain-ai.github.io/langgraph/reference/agents/#langgraph.prebuilt.chat_agent_executor.create_react_agent\n",
+    "\n",
+    "→ Technical reference for the create_react_agent function, including parameters, return types, and implementation details.\n",
+    "\n",
+    "\n",
+    "**2. LangGraph Structured Output Configuration**\n",
+    "\n",
+    "https://langchain-ai.github.io/langgraph/agents/agents/#6-configure-structured-output\n",
+    "\n",
+    "→ Documentation on configuring structured output in LangGraph agents, including response_format and output parsing options.\n",
+    "\n",
+    "\n",
+    "**3. LangGraph ReAct Agent with Structured Output Tutorial**\n",
+    "\n",
+    "https://langchain-ai.github.io/langgraph/how-tos/react-agent-structured-output/\n",
+    "\n",
+    "→ Step-by-step guide on implementing structured output with ReAct agents, including examples and best practices."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ Each lesson will have a dedicated video tutorial. Links will be provided as less
    - Combining both techniques to build sophisticated agents that can switch between financial advisor, teacher, or summarizer roles
    - Real-world example: Building a financial analysis agent that adapts both its underlying model and persona based on query complexity
    - [LangGraph Advanced – Build AI Agents with Dynamic Model Selection and Role Switching](https://www.youtube.com/watch?v=bV1K8B4m5PI)
-3. **Lesson 3:** (Coming soon)
+3. **Structured Output with Prebuilt Agents** ([03_structured_output_with_prebuilt_agents.ipynb](03_structured_output_with_prebuilt_agents.ipynb))
+   - Why structured output matters for production apps that need machine-readable results, not just chat text
+   - Define a Pydantic schema (e.g., `FinancialInfo`) and pass it via `response_format` to `create_react_agent` (v2)
+   - Understand the added graph step to generate a structured response and how to access it from the agent state
+   - Trade-offs: extra LLM call cost; alternatives include treating the schema as a tool or using a post-model hook with custom state to capture JSON without extra calls
+   - Real-world example: TSLA analysis producing JSON fields like company_name, stock_symbol, current_price, market_cap, summary, risk_assessment
+   - [LangGraph Advanced – Generate Structured Output in AI Agents Using Prebuilt LangGraph APIs](https://www.youtube.com/watch?v=3Q31aObRBMo)
 
 *This list will be updated as new lessons are added. Each lesson will include code, explanations, and a video walkthrough.*
 


### PR DESCRIPTION
- Add new notebook: 03_structured_output_with_prebuilt_agents.ipynb
  - Define Pydantic schema `FinancialInfo` and use `response_format` with `create_react_agent` (v2)
  - Demonstrate the added `generate_structured_response` step and how to read structured output from agent state
  - Real-world example: TSLA analysis producing JSON fields (company_name, stock_symbol, current_price, market_cap, summary, risk_assessment)
  - Discuss trade-offs (extra LLM call cost) and alternatives:
    - Treat schema as a tool to avoid the extra call
    - Use a post-model hook with a custom AgentState to capture JSON without additional calls

- Update README.md:
  - Add Lesson 3 section with structured output overview, key takeaways, and video link
  - Link: https://www.youtube.com/watch?v=3Q31aObRBMo