### PR TITLE
feat: add semantic search for large toolsets with langgraph-bigtool

### DIFF
--- a/14_bigtool_semantic_search.ipynb
+++ b/14_bigtool_semantic_search.ipynb
@@ -1,0 +1,309 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "97f9ae5b",
+   "metadata": {},
+   "source": [
+    "# Langgraph Bigtool + Long Memory's Similarity Search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "820f5435",
+   "metadata": {},
+   "source": [
+    "## Load MCP Tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5755e478",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "\n",
+    "def load_mcp_servers(config_path):\n",
+    "    \"\"\"\n",
+    "    Load MCP server definitions from a JSON config file.\n",
+    "    Expects a top-level 'mcpServers' dict in the config.\n",
+    "    \"\"\"\n",
+    "    if not os.path.exists(config_path):\n",
+    "        raise FileNotFoundError(f\"Config file not found: {config_path}\")\n",
+    "    with open(config_path, \"r\") as f:\n",
+    "        config = json.load(f)\n",
+    "    servers = config.get(\"mcpServers\", {})\n",
+    "    # Optionally add default transports if missing\n",
+    "    for name, server in servers.items():\n",
+    "        if \"command\" in server and \"transport\" not in server:\n",
+    "            server[\"transport\"] = \"stdio\"\n",
+    "        if \"url\" in server and \"transport\" not in server:\n",
+    "            server[\"transport\"] = \"streamable_http\"\n",
+    "    return servers\n",
+    "\n",
+    "mcp_servers = load_mcp_servers(\"./mcp_config.json\")\n",
+    "mcp_servers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9e33d7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_mcp_adapters.client import MultiServerMCPClient\n",
+    "\n",
+    "client = MultiServerMCPClient(mcp_servers)\n",
+    "mcp_tools = await client.get_tools()\n",
+    "\n",
+    "print(f\"Loaded {len(mcp_tools)} tools.\\n\")\n",
+    "print(f\"Example of a tool:\\n{mcp_tools[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6241479",
+   "metadata": {},
+   "source": [
+    "## Define Tool Registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d55f6b8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import uuid\n",
+    "\n",
+    "EXCLUDED_TOOLS = {\"search_repositories\"}\n",
+    "\n",
+    "# Create registry of tools. This is a dict mapping\n",
+    "# identifiers to tool instances.\n",
+    "tool_registry = {\n",
+    "    str(uuid.uuid4()): tool\n",
+    "    for tool in mcp_tools\n",
+    "    if tool.name not in EXCLUDED_TOOLS\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6805f4e6",
+   "metadata": {},
+   "source": [
+    "## Init Long Memory with Tools definitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "975af6fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.embeddings import init_embeddings\n",
+    "from langgraph.store.memory import InMemoryStore\n",
+    "\n",
+    "# Index tool names and descriptions in the LangGraph\n",
+    "# Store. Here we use a simple in-memory store.\n",
+    "embeddings = init_embeddings(\"openai:text-embedding-3-small\")\n",
+    "\n",
+    "store = InMemoryStore(\n",
+    "    index={\n",
+    "        \"embed\": embeddings,\n",
+    "        \"dims\": 1536,\n",
+    "        \"fields\": [\"description\"],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "for tool_id, tool in tool_registry.items():\n",
+    "    store.put(\n",
+    "        (\"tools\",),\n",
+    "        tool_id,\n",
+    "        {\n",
+    "            \"description\": f\"{tool.name}: {tool.description}\",\n",
+    "        },\n",
+    "    )\n",
+    "\n",
+    "store.search((\"tools\",))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a08391ff",
+   "metadata": {},
+   "source": [
+    "### testing RAG for tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1f936d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve relevant tools based on user query\n",
+    "relevant_tools = store.search(\n",
+    "    (\"tools\",),\n",
+    "    query=\"I want to create a GitHub issue\",\n",
+    "    limit=5\n",
+    ")\n",
+    "\n",
+    "for tool in relevant_tools:\n",
+    "    print(f\"- {tool}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bdf1811",
+   "metadata": {},
+   "source": [
+    "btw you can also use this technique for Dynamic Tools Selection (previous lesson) instead of LLM categorizations via structured output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1cf9b69",
+   "metadata": {},
+   "source": [
+    "## Create Bigtool Agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1a64e40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph_bigtool import create_agent\n",
+    "from langchain.chat_models import init_chat_model\n",
+    "from tools import draw_mermaid_png\n",
+    "\n",
+    "# Initialize agent\n",
+    "model = init_chat_model(\"openai:gpt-4o-mini\")\n",
+    "\n",
+    "builder = create_agent(model, tool_registry, limit=5)\n",
+    "bigtool_agent = builder.compile(store=store)\n",
+    "\n",
+    "draw_mermaid_png(bigtool_agent)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8f50aae",
+   "metadata": {},
+   "source": [
+    "## Testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea36c4b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage\n",
+    "from textwrap import dedent\n",
+    "\n",
+    "user_query = \"\"\"\n",
+    "Create a new issue in the langgraph-advanced repository in my account with the following details:\n",
+    "\n",
+    "Title: \"Add documentation for bigtool example\"\n",
+    "\n",
+    "Description: \n",
+    "This issue tracks the need to document the bigtool pattern for handling large numbers of tools.\n",
+    "The documentation should cover:\n",
+    "- How semantic search is used to retrieve relevant tools\n",
+    "- The difference between bigtool and standard tool binding\n",
+    "- Best practices for tool descriptions to improve retrieval accuracy\n",
+    "- Example use cases demonstrating the pattern\n",
+    "\n",
+    "This will help users understand when and how to use the bigtool library effectively.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "result = await bigtool_agent.ainvoke(\n",
+    "    {\"messages\": [HumanMessage(content=user_query)]}\n",
+    ")\n",
+    "\n",
+    "for message in result['messages']:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22b5a0ef",
+   "metadata": {},
+   "source": [
+    "### What the LLM Sees (Tool Schema) and why this is less favorable way\n",
+    "\n",
+    "```\n",
+    "{\n",
+    "  \"name\": \"retrieve_tools\",\n",
+    "  \"description\": \"Retrieve relevant tools based on a search query.\",\n",
+    "  \"parameters\": {\n",
+    "    \"type\": \"object\",\n",
+    "    \"properties\": {\n",
+    "      \"query\": {\n",
+    "        \"type\": \"string\",\n",
+    "        \"description\": \"Search query\"\n",
+    "      }\n",
+    "    },\n",
+    "    \"required\": [\"query\"]\n",
+    "  }\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7933965",
+   "metadata": {},
+   "source": [
+    "## Reference Links\n",
+    "\n",
+    "**1. Handling Large Numbers of Tools in LangGraph**\n",
+    "\n",
+    "https://langchain-ai.github.io/langgraph/how-tos/tool-calling/#handle-large-numbers-of-tools\n",
+    "\n",
+    "→ Guide to managing agents with many tools using semantic search and filtering strategies to reduce context size and improve tool selection accuracy.\n",
+    "\n",
+    "**2. LangGraph BigTool: GitHub Repository**\n",
+    "\n",
+    "https://github.com/langchain-ai/langgraph-bigtool\n",
+    "\n",
+    "→ Official package for semantic tool retrieval in LangGraph, enabling agents to work with large tool sets by dynamically selecting relevant tools based on query similarity."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ Each lesson will have a dedicated video tutorial. Links will be provided as less
   - Apply this pattern to any agent with large tool sets (MCP servers, API collections, enterprise tool catalogs) to maintain predictable behavior as your tool library grows.
   - [LangGraph Advanced – Dynamically Select Tools in AI Agents for Cleaner and Smarter Workflows](https://www.youtube.com/watch?v=qGaRj3lUfps)
 
+14. **Use LangGraph BigTool and Semantic Search to Manage Large Toolsets in AI Agents** ([14_bigtool_semantic_search.ipynb](14_bigtool_semantic_search.ipynb))
+  - Understand semantic search as an alternative to LLM-based tool selection: use embeddings and vector similarity instead of structured LLM calls to find relevant tools.
+  - Learn to build a tool registry with unique identifiers and index tool descriptions in `InMemoryStore` with embedding-based search capabilities (`text-embedding-3-small`).
+  - Master the `langgraph_bigtool.create_agent()` pattern: configure a `limit` parameter to retrieve only the top-N semantically similar tools per query, reducing context size automatically.
+  - Compare three approaches for large toolsets: (1) bind all tools (context pollution), (2) LLM pre-filtering (extra call + cost), (3) semantic search (no LLM call but less intelligent matching).
+  - Recognize the trade-off: semantic search is faster and cheaper but may miss tools with poor descriptions or subtle semantic differences; LLM selection is slower but more contextually aware.
+  - Apply this knowledge to choose the right tool selection strategy based on your constraints: latency requirements, cost budgets, tool description quality, and semantic diversity of your tool library.
+  - Discover how the same semantic search technique can replace LLM-based categorization from the previous lesson for dynamic tool selection in standard ReAct agents.
+  - [LangGraph Advanced – Use LangGraph BigTool and Semantic Search to Manage Large Toolsets in AI Agents](https://www.youtube.com/watch?v=iBcRiTtvBXU)
+
 ## Contributing
 
 Feedback and contributions are welcome! Please open issues or submit pull requests for suggestions and improvements.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ langgraph
 langgraph-supervisor
 langgraph-swarm
 langchain-mcp-adapters
+langgraph-bigtool
 
 trustcall
 yfinance

--- a/tools.py
+++ b/tools.py
@@ -4,7 +4,7 @@ from IPython.display import HTML, display
 from langchain_core.runnables.graph_mermaid import MermaidDrawMethod
 
 
-def draw_mermaid_png(agent, max_height="70vh", max_width="min(90vw, 720px)"):
+def draw_mermaid_png(agent, max_height="70vh", max_width="min(90vw, 500px)"):
     """
     Render a Mermaid graph locally while auto-scaling it for notebook display.
 


### PR DESCRIPTION
- Index 70+ MCP tools in InMemoryStore with text-embedding-3-small
- Use bigtool.create_agent() to retrieve top-5 semantically similar tools per query
- Compare approaches: bind all tools vs LLM filtering vs semantic search
- Demonstrate trade-offs: speed/cost vs contextual intelligence in tool selection