### PR TITLE
feat: add tool-level HITL with universal wrapper for third-party tools

### DIFF
--- a/16_tool_level_hitl_control.ipynb
+++ b/16_tool_level_hitl_control.ipynb
@@ -1,0 +1,500 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d841957d",
+   "metadata": {},
+   "source": [
+    "# Tool Level HITL Control\n",
+    "\n",
+    "You can use this to add HITL to any tool without having to add it inside the tool!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d899176",
+   "metadata": {},
+   "source": [
+    "### Define basic stuff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22bb8a07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import yfinance as yf\n",
+    "from pprint import pformat\n",
+    "from langchain_core.tools import tool\n",
+    "\n",
+    "\n",
+    "########################### Tools \n",
+    "@tool(\"lookup_stock\")\n",
+    "def lookup_stock_symbol(company_name: str) -> str:\n",
+    "    \"\"\"\n",
+    "    Converts a company name to its stock symbol using a financial API.\n",
+    "\n",
+    "    Parameters:\n",
+    "        company_name (str): The full company name (e.g., 'Tesla').\n",
+    "\n",
+    "    Returns:\n",
+    "        str: The stock symbol (e.g., 'TSLA') or an error message.\n",
+    "    \"\"\"\n",
+    "    api_url = \"https://www.alphavantage.co/query\"\n",
+    "    params = {\n",
+    "        \"function\": \"SYMBOL_SEARCH\",\n",
+    "        \"keywords\": company_name,\n",
+    "        \"apikey\": \"your_alphavantage_api_key\"\n",
+    "    }\n",
+    "    \n",
+    "    response = requests.get(api_url, params=params)\n",
+    "    data = response.json()\n",
+    "    \n",
+    "    if \"bestMatches\" in data and data[\"bestMatches\"]:\n",
+    "        return data[\"bestMatches\"][0][\"1. symbol\"]\n",
+    "    else:\n",
+    "        return f\"Symbol not found for {company_name}.\"\n",
+    "\n",
+    "\n",
+    "@tool(\"fetch_stock_data\")\n",
+    "def fetch_stock_data_raw(stock_symbol: str) -> dict:\n",
+    "    \"\"\"\n",
+    "    Fetches comprehensive stock data for a given symbol and returns it as a combined dictionary.\n",
+    "\n",
+    "    Parameters:\n",
+    "        stock_symbol (str): The stock ticker symbol (e.g., 'TSLA').\n",
+    "        period (str): The period to analyze (e.g., '1mo', '3mo', '1y').\n",
+    "\n",
+    "    Returns:\n",
+    "        dict: A dictionary combining general stock info and historical market data.\n",
+    "    \"\"\"\n",
+    "    period = \"1mo\"\n",
+    "    try:\n",
+    "        stock = yf.Ticker(stock_symbol)\n",
+    "\n",
+    "        # Retrieve general stock info and historical market data\n",
+    "        stock_info = stock.info  # Basic company and stock data\n",
+    "        stock_history = stock.history(period=period).to_dict()  # Historical OHLCV data\n",
+    "\n",
+    "        # Combine both into a single dictionary\n",
+    "        combined_data = {\n",
+    "            \"stock_symbol\": stock_symbol,\n",
+    "            \"info\": stock_info,\n",
+    "            \"history\": stock_history\n",
+    "        }\n",
+    "\n",
+    "        return pformat(combined_data)\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        return {\"error\": f\"Error fetching stock data for {stock_symbol}: {str(e)}\"}\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def place_order(\n",
+    "    symbol: str,\n",
+    "    action: str,\n",
+    "    shares: int,\n",
+    "    limit_price: float,\n",
+    "    order_type: str = \"limit\",\n",
+    ") -> dict:\n",
+    "    \"\"\"\n",
+    "    Execute a stock order.\n",
+    "\n",
+    "    Parameters:\n",
+    "    - symbol: Ticker\n",
+    "    - action: \"buy\" or \"sell\"\n",
+    "    - shares: Number of shares to trade (pre-computed by the agent)\n",
+    "    - limit_price: Limit price per share\n",
+    "    - order_type: Order type, default \"limit\"\n",
+    "\n",
+    "    Returns:\n",
+    "    - status: Execution result (simulated)\n",
+    "    - symbol\n",
+    "    - shares\n",
+    "    - limit_price\n",
+    "    - total_spent\n",
+    "    - type: Order type used\n",
+    "    - action\n",
+    "    \"\"\"\n",
+    "    total_spent = round(int(shares) * limit_price, 2)\n",
+    "    return {\n",
+    "        \"status\": \"filled\",\n",
+    "        \"symbol\": symbol,\n",
+    "        \"shares\": int(shares),\n",
+    "        \"limit_price\": limit_price,\n",
+    "        \"total_spent\": total_spent,\n",
+    "        \"type\": order_type,\n",
+    "        \"action\": action,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "########################### Prompt\n",
+    "system_message = \"\"\"\n",
+    "You are a financial advisor assistant. Use the provided tools to ground your answers\n",
+    "in up-to-date market data. Be concise, factual, and risk-aware.\n",
+    "\n",
+    "Be decisive: when you have sufficient information to act, proceed with tool calls without\n",
+    "asking for confirmation. Only if information is missing or uncertain, ask a concise \n",
+    "clarifying question.\n",
+    "\n",
+    "When preparing or describing actions, include appropriate parameters (e.g., symbol, shares,\n",
+    "limit price, budgets) based on available data. Do not fabricate numbers or facts.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "########################### pretty printing\n",
+    "def print_tool_approval(payload):\n",
+    "    tool = payload.get(\"awaiting\", \"unknown_tool\")\n",
+    "    args = payload.get(\"args\", {})\n",
+    "\n",
+    "    print(\"—-- Approval needed —--\")\n",
+    "    print(f\"Tool: {tool}\")\n",
+    "\n",
+    "    if isinstance(args, dict) and args:\n",
+    "        print(\"Parameters:\")\n",
+    "        for k, v in args.items():\n",
+    "            print(f\"  - {k}: {v}\")\n",
+    "    elif args:\n",
+    "        print(f\"Parameters: {args}\")\n",
+    "    else:\n",
+    "        print(\"No parameters.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c9c8644",
+   "metadata": {},
+   "source": [
+    "## Use post model hook for Risky Tools (previous experience from lesson 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75734acd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.checkpoint.memory import InMemorySaver\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from tools import draw_mermaid_png\n",
+    "from langchain_core.messages import AIMessage\n",
+    "from langgraph.types import interrupt\n",
+    "\n",
+    "RISKY_TOOLS = {\"place_order\"}\n",
+    "\n",
+    "def halt_on_risky_tools(state):\n",
+    "    last = state[\"messages\"][-1]\n",
+    "    if isinstance(last, AIMessage) and getattr(last, \"tool_calls\", None):\n",
+    "        for tc in last.tool_calls:\n",
+    "            if tc.get(\"name\") in RISKY_TOOLS:\n",
+    "                decision = interrupt({\"awaiting\": tc[\"name\"], \"args\": tc.get(\"args\", {})})\n",
+    "\n",
+    "                # tool approved\n",
+    "                if isinstance(decision, dict) and decision.get(\"approved\"):\n",
+    "                    return {}\n",
+    "\n",
+    "                # tool rejected\n",
+    "                tool_msg = ToolMessage(\n",
+    "                    content=f\"Cancelled by human. Continue without executing that tool and provide next steps.\",\n",
+    "                    tool_call_id=tc[\"id\"],\n",
+    "                    name=tc[\"name\"]\n",
+    "                )\n",
+    "                return {\"messages\": [tool_msg]}\n",
+    "\n",
+    "    return {}\n",
+    "\n",
+    "agent = create_react_agent(\n",
+    "    model=\"openai:gpt-4o-mini\",\n",
+    "    tools=[lookup_stock_symbol, fetch_stock_data_raw, place_order],\n",
+    "    prompt=system_message,\n",
+    "    checkpointer=InMemorySaver(),\n",
+    "\n",
+    "    version=\"v2\",\n",
+    "    post_model_hook=halt_on_risky_tools\n",
+    ")\n",
+    "\n",
+    "draw_mermaid_png(agent)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a121bcb",
+   "metadata": {},
+   "source": [
+    "## Introduce a universal tool wrapper for HITL (you can wrap any tool you need!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "995226fe",
+   "metadata": {},
+   "source": [
+    "### create wrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc7c346f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Callable\n",
+    "from langchain_core.tools import BaseTool, tool\n",
+    "from langchain_core.runnables import RunnableConfig\n",
+    "from langgraph.types import interrupt\n",
+    "\n",
+    "def add_approval(main_tool: Callable | BaseTool) -> BaseTool:\n",
+    "    \"\"\"Wrap a tool to support human-in-the-loop review.\"\"\"\n",
+    "    if not isinstance(main_tool, BaseTool):\n",
+    "        main_tool = tool(main_tool)\n",
+    "\n",
+    "    @tool(  \n",
+    "        main_tool.name,\n",
+    "        description=main_tool.description,\n",
+    "        args_schema=main_tool.args_schema\n",
+    "    )\n",
+    "    def call_main_tool_with_hitl(config: RunnableConfig, **tool_input):\n",
+    "        decision = interrupt({\n",
+    "            \"awaiting\": main_tool.name,\n",
+    "            \"args\": tool_input\n",
+    "        })\n",
+    "\n",
+    "        # tool approved\n",
+    "        if isinstance(decision, dict) and decision.get(\"approved\"):\n",
+    "            return main_tool.invoke(tool_input, config)\n",
+    "\n",
+    "        # tool rejected\n",
+    "        return \"Cancelled by human. Continue without executing that tool and provide next steps.\"\n",
+    "        \n",
+    "\n",
+    "    return call_main_tool_with_hitl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "763d7dc3",
+   "metadata": {},
+   "source": [
+    "## prepare list of available tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "026326ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RISKY_TOOLS = {\"place_order\"}\n",
+    "\n",
+    "tools = [lookup_stock_symbol, fetch_stock_data_raw, place_order]\n",
+    "\n",
+    "# Wrap risky tools with approval mechanism\n",
+    "tools = [\n",
+    "    add_approval(tool) if tool.name in RISKY_TOOLS else tool\n",
+    "    for tool in tools\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e455de62",
+   "metadata": {},
+   "source": [
+    "### create ReAct agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abd32e21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent = create_react_agent(\n",
+    "    model=\"openai:gpt-4o-mini\",\n",
+    "    tools=tools,\n",
+    "    prompt=system_message,\n",
+    "    checkpointer=InMemorySaver(),\n",
+    ")\n",
+    "\n",
+    "draw_mermaid_png(agent)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30af47f0",
+   "metadata": {},
+   "source": [
+    "## Testing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "203e466a",
+   "metadata": {},
+   "source": [
+    "### Approval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddd1c27c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage\n",
+    "import uuid\n",
+    "\n",
+    "config = {\n",
+    "    \"configurable\": {\n",
+    "        \"thread_id\": str(uuid.uuid4())\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "response = agent.invoke({\"messages\": [HumanMessage(content=\"Buy $1000 of Tesla stock at the current price.\")]}, config)\n",
+    "for message in response['messages']:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64e92c6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interrupts = response[\"__interrupt__\"]\n",
+    "print_tool_approval(interrupts[0].value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30fd51b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.types import Command\n",
+    "\n",
+    "response = agent.invoke(Command(resume={\"approved\": True}), config=config)\n",
+    "for message in response['messages']:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d40749fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"__interrupt__\" in response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c414ec65",
+   "metadata": {},
+   "source": [
+    "### Cancel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61f11af8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage\n",
+    "import uuid\n",
+    "\n",
+    "config = {\n",
+    "    \"configurable\": {\n",
+    "        \"thread_id\": str(uuid.uuid4())\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "response = agent.invoke({\"messages\": [HumanMessage(content=\"Buy $1000 of Tesla stock at the current price.\")]}, config)\n",
+    "for message in response['messages']:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08efe4c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interrupts = response[\"__interrupt__\"]\n",
+    "print_tool_approval(interrupts[0].value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c84ecec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = agent.invoke(Command(resume={\"approved\": False}), config=config)\n",
+    "for message in response['messages']:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db1aba0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"__interrupt__\" in response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e6d84ec",
+   "metadata": {},
+   "source": [
+    "## Reference Links\n",
+    "\n",
+    "**1. Human-in-the-Loop: Add Interrupts to Any Tool**\n",
+    "\n",
+    "https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/add-human-in-the-loop/#add-interrupts-to-any-tool\n",
+    "\n",
+    "→ Guide to wrapping tools with human-in-the-loop interrupts, enabling approval workflows for specific tool calls before execution, with patterns for tool interception and user confirmation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ Each lesson will have a dedicated video tutorial. Links will be provided as less
   - Recognize when to use each HITL pattern: approval gates for risk management (risky actions), query tools for information gathering (missing parameters, user preferences, clarifications).
   - [LangGraph Advanced – Let AI Agents Ask Humans: Build Dynamic Human-in-the-Loop Workflows](https://www.youtube.com/watch?v=QS2NjzAQGUY)
 
+16. **Add Human-in-the-Loop Control Directly to Tools in AI Agent Workflows** ([16_tool_level_hitl_control.ipynb](16_tool_level_hitl_control.ipynb))
+  - Learn the limitation of `post_model_hook` HITL (Lesson 4): requires modifying agent configuration and doesn't work with third-party tools like MCP tools that you don't control.
+  - Master the `add_approval()` wrapper pattern: create a universal decorator that wraps any tool (including MCP tools) with HITL logic without modifying the original tool code.
+  - Understand the wrapper implementation: intercept tool calls with `interrupt()`, wait for approval decision, execute the original tool if approved, or return cancellation message if declined.
+  - Compare two HITL approaches: (1) `post_model_hook` (agent-level, requires agent modification), (2) tool wrapper (tool-level, works with any tool including third-party).
+  - Apply selective wrapping: use list comprehension to wrap only risky tools (`add_approval(tool) if tool.name in RISKY_TOOLS else tool`) while leaving safe tools unchanged.
+  - Recognize the key advantage: tool wrappers enable HITL for tools you don't own or can't modify (MCP servers, external APIs, library tools) by adding approval logic at the integration layer.
+  - Implement the same approve/decline flow as Lesson 4 but with cleaner separation: HITL logic lives in the wrapper, not in agent hooks, making it reusable across different agents and architectures.
+  - [LangGraph Advanced – Add Human in the Loop Control Directly to Tools in AI Agent Workflows](https://www.youtube.com/watch?v=snI7BvB4Qxg)
+
+
 ## Contributing
 
 Feedback and contributions are welcome! Please open issues or submit pull requests for suggestions and improvements.


### PR DESCRIPTION
- Implement add_approval() wrapper to add HITL to any tool without modifying source
- Enable HITL for MCP tools and external APIs via tool interception pattern
- Compare agent-level (post_model_hook) vs tool-level (wrapper) HITL approaches
- Demonstrate selective wrapping for risky tools with reusable approval logic